### PR TITLE
Update readme with fixes to grammar, as well as add instructions to a…

### DIFF
--- a/Journal/EntryController.swift
+++ b/Journal/EntryController.swift
@@ -18,7 +18,9 @@ class EntryController {
         loadFromPersistentStorage()
     }
     
-    func add(entry: Entry) {
+    func addEntryWith(title: String, text: String) {
+        
+        let entry = Entry(title: title, text: text)
         
         entries.append(entry)
         
@@ -31,6 +33,13 @@ class EntryController {
             entries.remove(at: entryIndex)
         }
         
+        saveToPersistentStorage()
+    }
+    
+    func update(entry: Entry, with title: String, text: String) {
+        
+        entry.title = title
+        entry.text = text
         saveToPersistentStorage()
     }
 	

--- a/Journal/EntryDetailViewController.swift
+++ b/Journal/EntryDetailViewController.swift
@@ -9,61 +9,59 @@
 import UIKit
 
 class EntryDetailViewController: UIViewController, UITextFieldDelegate {
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-		
-		updateViews()
-	}
-	
-	// MARK: Actions
-	
-	@IBAction func saveButtonTapped(_ sender: Any) {
-		
-		if let entry = self.entry {
-			entry.title = self.titleTextField.text!
-			entry.text = self.bodyTextView.text
-			entry.timestamp = Date()
-		} else {
-			let newEntry = Entry(title: self.titleTextField.text!, text: self.bodyTextView.text)
-			EntryController.shared.add(entry: newEntry)
-			entry = newEntry
-		}
-		
-		let _ = self.navigationController?.popViewController(animated: true)
-	}
-	
-	@IBAction func clearButtonTapped(_ sender: Any) {
-		
-		titleTextField.text = ""
-		bodyTextView.text = ""
-	}
-	
-	// MARK: Private
-	
-	private func updateViews() {
-		guard let entry = entry else { return }
-		titleTextField.text = entry.title
-		bodyTextView.text = entry.text
-	}
-	
-	// MARK: UITextFieldDelegate
-	
-	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-		
-		textField.resignFirstResponder()
-		
-		return true
-	}
-	
-	// MARK: Properties
-	
-	var entry: Entry? {
-		didSet {
-			updateViews()
-		}
-	}
-	
-	@IBOutlet weak var titleTextField: UITextField!
-	@IBOutlet weak var bodyTextView: UITextView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        updateViews()
+    }
+    
+    // MARK: Actions
+    
+    @IBAction func saveButtonTapped(_ sender: Any) {
+        
+        guard let title = titleTextField.text, let text = bodyTextView.text else { return }
+        
+        if let entry = self.entry {
+            EntryController.shared.update(entry: entry, with: title, text: text)
+        } else {
+            EntryController.shared.addEntryWith(title: title, text: text)
+        }
+        
+        let _ = self.navigationController?.popViewController(animated: true)
+    }
+    
+    @IBAction func clearButtonTapped(_ sender: Any) {
+        
+        titleTextField.text = ""
+        bodyTextView.text = ""
+    }
+    
+    // MARK: Private
+    
+    private func updateViews() {
+        guard let entry = entry else { return }
+        titleTextField.text = entry.title
+        bodyTextView.text = entry.text
+    }
+    
+    // MARK: UITextFieldDelegate
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        
+        textField.resignFirstResponder()
+        
+        return true
+    }
+    
+    // MARK: Properties
+    
+    var entry: Entry? {
+        didSet {
+            if isViewLoaded { updateViews() }
+        }
+    }
+    
+    @IBOutlet weak var titleTextField: UITextField!
+    @IBOutlet weak var bodyTextView: UITextView!
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Level 1
 
-Students will build a simple Journal app to practice MVC separation, protocols, master-detail interfaces, table views, and persistence. 
+Students will build a simple journal app to practice MVC separation, protocols, master-detail interfaces, table views, and persistence. 
 
 Journal is an excellent app to practice basic Cocoa Touch princples and design patterns. Students are encouraged to repeat building Journal regularly until the principles and patterns are internalized and the student can build Journal without a guide.
 
@@ -10,50 +10,52 @@ Students who complete this project independently are able to:
 
 ### Part One - Model Objects and Controllers
 
-* understand basic model-view-controller design and implementation
-* create a custom model object with a memberwise initializer
-* understand, create, and use a shared instance
-* create a model object controller with create, read, update, delete functions
-* implement the Equatable protocol
+* Understand basic model-view-controller design and implementation
+* Create a custom model object with a memberwise initializer
+* Understand, create, and use a shared instance
+* Create a model object controller with create, read, update, and delete functions
+* Implement the Equatable protocol
 
 ### Part Two - User Interface
 
-* implement a master-detail interface
-* implement the UITableViewDataSource protocol
-* understand and implement the UITextFieldDelegate protocol to dismiss the keyboard
-* create relationship segues in Storyboards
-* understand, use, and implement the 'updateViews' pattern
-* implement 'prepare(for segue: UIStoryboardSegue, sender: Any?)' to configure destination view controllers
+* Implement a master-detail interface
+* Implement the UITableViewDataSource protocol
+* Understand and implement the UITextFieldDelegate protocol to dismiss the keyboard
+* Create relationship segues in Storyboards
+* Understand, use, and implement the 'updateViews' pattern
+* Implement 'prepare(for segue: UIStoryboardSegue, sender: Any?)' to configure destination view controllers
 
 ### Part Three - Controller Implementation
 
-* add data persistence using UserDefaults
-* create a custom model object with a failable initializer
-* use the array map function to translate objects
+* Add data persistence using UserDefaults
+* Create a custom model object with a failable initializer
+* Use the array map function to translate objects
 
 ## Part One - Model Objects and Controllers
 
 ### Entry
 
-Create an Entry model class that will hold a title, text, and timestamp for each entry.
+Create an Entry model class that will hold title, text, and timestamp properties for each entry.
 
 1. Add a new `Entry.swift` file and define a new `Entry` class
 2. Add properties for timestamp, title, and body text
 3. Add a memberwise initializer that takes parameters for each property
-    * note: Consider setting a default parameter value for timestamp.
+* Consider setting a default parameter value for timestamp.
 
 ### EntryController
 
-Create a model object controller called EntryController that will manage adding, reading, updating, and removing entries. We will follow the shared instance design pattern because we want one consistent source of truth for our entry objects that are held on the controller.
+Create a model object controller called `EntryController` that will manage adding, reading, updating, and removing entries. We will follow the shared instance design pattern because we want one consistent source of truth for our entry objects that are held on the controller.
 
 1. Add a new `EntryController.swift` file and define a new `EntryController` class inside.
-2. Add an empty entries Array property
-3. Create a `add(entry: Entry)` function that adds the entry parameter to the entries array
+2. Add an entries array property, and set its value to an empty array
+3. Create a `addEntryWith(title: ...)` function that takes in a `title`, and `text`, creates a new instance of `Entry`, and adds it to the entries array
 4. Create a `remove(entry: Entry)` function that removes the entry from the entries array
-    * note: There is no 'removeObject' function on arrays. You will need to find the index of the object and then remove the object at that index.
-    * note: You will face a compiler error because we have not given the Entry class a way to find equal objects. You will resolve the error by implementing the Equatable protocol in the next step.
-5. Create a `shared` property as a shared instance. 
-    * note: Review the syntax for creating shared instance properties
+* There is no 'removeObject' function on arrays. You will need to find the index of the object and then remove the object at that index.
+* You will face a compiler error because we have not given the Entry class a way to find equal objects. You will resolve the error by implementing the Equatable protocol in the next step.
+
+5. Create an `update(entry: ...)` function that should take in an existing entry as a parameter, as well as the title and text strings to update the entry with
+6. Create a `shared` property as a shared instance
+* Review the syntax for creating shared instance properties
 
 ### Equatable Protocol
 
@@ -82,18 +84,18 @@ Uncomment any relevant tests for this part. Verify that required classes are mem
 
 Build a view that lists all journal entries. You will use a UITableViewController and implement the UITableViewDataSource functions.
 
-The UITableViewController subclass template comes with a lot of boilerplate and commented code. For readability, please remove all unused boilerplate from your code. 
+The UITableViewController subclass template comes with a lot of boilerplate and commented code. For readability, please remove all unnecessary boilerplate from your code. 
 
 You will want this view to reload the table view each time it appears in order to display newly created entries.
 
 1. Add a UITableViewController as your root view controller in Main.storyboard and embed it into a UINavigationController
 2. Create an EntryListTableViewController file as a subclass of UITableViewController and set the class of your root view controller scene
 3. Implement the UITableViewDataSource functions using the EntryController entries array
-    * note: Pay attention to your `reuseIdentifier` in the Storyboard scene and your `dequeueReusableCell(withIdentifier:for:)` function call
+* Pay attention to your `reuseIdentifier` in the Storyboard scene and your `dequeueReusableCell(withIdentifier:for:)` function call
 4. Set up your cells to display the title of the entry
 5. Implement the UITableViewDataSource `tableView(_:commit:forRowAt:)` function to enable swipe to delete functionality
 6. Add a UIBarButtonItem to the UINavigationBar with the plus symbol
-    * note: Select 'Add' in the System Item menu from the Identity Inspector to set the button as a plus symbol, these are system bar button items, and include localization and other benefits
+* Select 'Add' in the System Item menu from the Identity Inspector to set the button as a plus symbol, these are system bar button items, and include localization and other benefits
 
 ### Detail View
 
@@ -103,16 +105,16 @@ Your Detail View should follow the 'updateViews' pattern for updating the view e
 
 1. Add an `EntryDetailViewController` file as a subclass of UIViewController and an optional `entry` property to the class 
 2. Add a UIViewController scene to Main.storyboard and set the class to `EntryDetailViewController`
-3. Add a UITextField for the entry's title text to the top of the scene, add an outlet to the class file (titleTextField), and set the delegate relationship
-    * note: To set the delegate relationship control drag from the UITextField to the current view controller in the scene dock 
+3. Add a UITextField for the entry's title text to the top of the scene, add an outlet to the class file called `titleTextField`, and set the delegate relationship
+* To set the delegate relationship control drag from the UITextField to the current view controller in the scene dock 
 4. Implement the delegate function `textFieldShouldReturn` to resign first responder to dismiss the keyboard
-    * note: Before you implement the delegate function be sure to adopt the UITextFieldDelegate protocol 
-5. Add a UITextView for the entry's body text beneath the title text field and add an outlet to the class file (bodyTextView).
+* Before you implement the delegate function be sure to adopt the UITextFieldDelegate protocol 
+5. Add a UITextView for the entry's body text beneath the title text field and add an outlet to the class file `bodyTextView`.
 6. Add a UIButton beneath the body text view and add an IBAction to the class file that clears the text in the titleTextField and bodyTextView.
 7. Add a UIBarButtonItem to the UINavigationBar as a Save System Item and add an IBAction to the class file
-    * note: You may need to add a segue to see a UINavigationBar on the detail view, and a UINavigationItem to add the UIBarButtonItem to the UINavigationBar, this will be covered in the next section
-8. In the IBAction check if the optional `entry` property holds an entry, if so, update the properties of the entry. If not, call the `add(entry: Entry)` function on the `EntryController`. After saving the entry, dismiss the current view.
-9. Add an `updateViews()` function that checks if the optional `entry` property holds an entry. If it doesn, implement the function to update all view elements that reflect details about the model object (in this case, the titleTextField and bodyTextView)
+* You may need to add a segue to see a UINavigationBar on the detail view, and a UINavigationItem to add the UIBarButtonItem to the UINavigationBar, this will be covered in the next section
+8. In the IBAction check if the optional `entry` property holds an entry, if so, call the `update(entry: ...)` function in the `EntryController` to  update the properties of the entry. If not, call the `add(entry: Entry)` function on the `EntryController`. After adding a new entry, or updating the existing entry, dismiss the current view.
+9. Add an `updateViews()` function that checks if the optional `entry` property holds an entry. If it doesn't, implement the function to update all view elements that reflect details about the model object (in this case, the titleTextField and bodyTextView)
 10. Make your `entry` property a computed property and call `updateViews()` whenever that property gets set
 11. Update the `viewDidLoad()` function to call `updateViews()`
 
@@ -121,14 +123,14 @@ Your Detail View should follow the 'updateViews' pattern for updating the view e
 You will add two separate segues from the List View to the Detail View. The segue from the plus button will tell the EntryDetailViewController that it should create a new entry. The segue from a selected cell will tell the EntryDetailViewController that it should display a previously created entry, and save any changes to the same.
 
 1. Add a 'show' segue from the Add button to the EntryDetailViewController scene and give the segue an identifier
-    * note: Consider that this segue will be used to add an entry when naming the identifier
+* Consider that this segue will be used to add an entry when naming the identifier
 2. Add a 'show' segue from the table view cell to the EntryDetailViewController scene and give the segue an identifier
-    * note: Consider that this segue will be used to edit an entry when naming the identifier
+* Consider that this segue will be used to edit an entry when naming the identifier
 3. Add a `prepare(for segue: UIStoryboardSegue, sender: Any?)` function to the EntryListTableViewController
 4. Implement the `prepare(for segue: UIStoryboardSegue, sender: Any?)` function. If the identifier is 'toShowEntry' we will pass the selected entry to the DetailViewController, which will call our `updateViews()` function 
-    * note: You will need to capture the selected entry by using the indexPath of the selected cell
-    * note: Remember that the `updateViews()` function will update the destination view controller with the entry details
-    * note: Since we aren't passing an entry if the identifier is 'toAddEntry' we don't need to account for this in our `prepare(for segue: UIStoryboardSegue, sender: Any?)`
+* You will need to capture the selected entry by using the indexPath of the selected cell
+* Remember that the `updateViews()` function will update the destination view controller with the entry details
+* Since we aren't passing an entry if the identifier is 'toAddEntry' we don't need to account for this in our `prepare(for segue: UIStoryboardSegue, sender: Any?)`
 
 ### Black Diamonds
 
@@ -150,37 +152,37 @@ You will use UserDefaults to add basic data persistence to the Journal app.
 Because Entry class objects are not plist compatible, and UserDefaults will only store classes that are, we have two options:
 
 1. Implement NSCoding to allow native saving and loading from plist objects like UserDefaults
-2. Add factory functions to make Dictionary representations of the object and initialize new objects with a Dictionary
+2. Add factory functions to make a dictionary representation of the object and initialize new objects with a dictionary
 
 There are pros and cons to both approaches. We've opted to go with the latter because it is closer to working with network services and APIs which we will do later on in the course.
 
-1. Write a dictionaryRepresentation function that returns a Dictionary with keys and values matching the properties of the object.
-    * note: Avoid using 'Magic Strings' in your code. Create private string keys for the class for each property that will be stored to and pulled from a Dictionary (ex. `private static let TimeStampKey = "timestamp"`)
+1. Write a `dictionaryRepresentation` computed property that returns a dictionary with keys and values matching the properties of the object.
+* Avoid using 'magic strings' in your code. Create private string keys for the class for each property that will be stored to and pulled from a dictionary (ex. `private static let timeStampKey = "timestamp"`)
 
-2. Write a failable initializer that takes a Dictionary as a parameter and sets the timestamp, title, and text properties using the values from the dictionary.
-    * note: Use `guard let` to check the optional values in the Dictionary and return nil if any of the properties are missing
+2. Write a failable initializer that takes a dictionary as a parameter and sets the timestamp, title, and text properties using the values from the dictionary.
+* Use `guard let` to check the optional values in the dictionary and return nil if any of the properties are missing
 
-### Add UserDefaults Functionality to the EntryController
+### Add UserDefaults functionality to the EntryController
 
-Our EntryController object is the source of truth for entries. We are now adding a layer of persistent storage, so we need to update our EntryController to load entries from UserDefaults on initialization and save the entries to UserDefaults when they are updated.
+Our `EntryController` object is the source of truth for entries. We are now adding a layer of persistent storage, so we need to update our `EntryController` to load entries from UserDefaults on initialization and save the entries to UserDefaults when they are updated.
 
 1. Write a method called `saveToPersistentStorage()` that will save the current entries array to UserDefaults
-    * note: Map the entries array to an array of plist compatible dictionary copies
-    * note: Avoid 'Magic Strings' when saving to UserDefaults
+* Map the entries array to an array of plist compatible dictionary copies
+* Avoid 'magic strings' when saving to UserDefaults
 
 2. Write a method called `loadFromPersistentStorage()` that will load saved dictionary entries from UserDefaults and set `entries` to the results
-    * note: Use the Entry `init(dictionary: [String: Any])` in a flatMap function to turn the dictionaries into Entry class objects
+* Use the Entry `init(dictionary: [String: Any])` in a flatMap function to turn the dictionaries into Entry class objects
 
-3. Call the `loadFromPersistentStorage()` function when the EntryController is initialized
+3. Call the `loadFromPersistentStorage()` function when the `EntryController` is initialized
 
 4. Call the `saveToPersistentStorage()` any time that the list of entries is modified
 
 ### Black Diamonds
 
-* Add support for multiple journals by adding a Journal object that holds entries, a Journal List View that displays Journals, and making the Entry List View display just the entries from the selected journal
+* Add support for multiple journals by adding a Journal object that holds entries, a Journal list view that displays Journals, and making the Entry list view display just the entries from the selected journal
 * Add support for tags on journals, add functionality to select a tag to display a list of entries with that tag
 * Implement the NSCoding protocol on the Entry class
-* Create a Unit test that verifies NSCoding functionality by converting an instance to and from NSData
+* Create a unit test that verifies NSCoding functionality by converting an instance to and from the `Data` class
 * Refactor persistence to work natively with Entry objects
 
 ### Tests
@@ -196,3 +198,4 @@ Please refer to CONTRIBUTING.md.
 ## Copyright
 
 © DevMountain LLC, 2015. Unauthorized use and/or duplication of this material without express and written permission from DevMountain, LLC is strictly prohibited. Excerpts and links may be used, provided that full and clear credit is given to DevMountain with appropriate and specific direction to the original content.
+


### PR DESCRIPTION
…dd an "update(entry: ...)" function that was missing. Without it, the user would not be able to have the changes to their entries persist.

Update addEntry function to take in the parameters needed to initialize an Entry, instead of having the Entry be initialized in a view controller.

Add an "update(entry: ...)" function in the EntryController to match the instructions.

Update saveButtonTapped IBAction to safely unwrap the text from the text field and view, and now calls the update(entry: ..." function.

The "updateViews" function on the EntryDetailViewController was crashing the app when being called in the didSet of the entry property. It appears the view isn't loaded prior to calling the didSet. When the function was called, it would crash because the textFields were nil. Now, it will only be called in the didSet if the view is already loaded. Otherwise, the viewDidLoad will call it.